### PR TITLE
Add number of cores when creating default cluster

### DIFF
--- a/R/clusterman.R
+++ b/R/clusterman.R
@@ -25,9 +25,10 @@ set_default_cluster <- function(x) {
 
 #' @export
 #' @rdname default_cluster
-get_default_cluster <- function() {
+#' @param ... Arguments passed on to \code{create_cluster()}.
+get_default_cluster <- function(...) {
   if (!cluster_exists()) {
-    x <- create_cluster()
+    x <- create_cluster(...)
     set_default_cluster(x)
   }
 

--- a/man/default_cluster.Rd
+++ b/man/default_cluster.Rd
@@ -8,10 +8,12 @@
 \usage{
 set_default_cluster(x)
 
-get_default_cluster()
+get_default_cluster(...)
 }
 \arguments{
 \item{x}{New cluster to use as default.}
+
+\item{...}{Arguments passed on to \code{create_cluster()}.}
 }
 \description{
 If no cluster is currently active, \code{get_default_cluster()} will create


### PR DESCRIPTION
Allow `get_default_cluster()` to create a cluster with a specified number of cores if there is no default cluster. 