### PR TITLE
use tidyselect::vars_pull() instead of dplyr:::find_var()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports:
     R6,
     rlang,
     tibble,
-    vctrs (>= 0.3.6)
+    vctrs (>= 0.3.6), 
+    tidyselect
 Suggests:
     covr,
     knitr,

--- a/R/partydf.R
+++ b/R/partydf.R
@@ -221,8 +221,7 @@ collect.multidplyr_party_df <- function(.data, ...) {
 #' @importFrom dplyr pull
 #' @export
 pull.multidplyr_party_df <- function(.data, var = -1) {
-  expr <- enquo(var)
-  var <- dplyr:::find_var(expr, tbl_vars(.data))
+  var <- tidyselect::vars_pull(tbl_vars(.data), {{ var }})
 
   .data <- ungroup(.data)
   .data <- select(.data, !!sym(var))


### PR DESCRIPTION
`find_var()` was removed in `dplyr` 1.0.8 release candidate and was called with `:::` anyway. 