### PR TITLE
dplyr 1.1.1 compatibility

### DIFF
--- a/tests/testthat/_snaps/dplyr-dual.md
+++ b/tests/testthat/_snaps/dplyr-dual.md
@@ -1,0 +1,9 @@
+# joining data frame requires explicit copy
+
+    Code
+      left_join(pf, df)
+    Condition
+      Error in `auto_copy()`:
+      ! `x` and `y` must share the same src.
+      i set `copy` = TRUE (may be slow).
+

--- a/tests/testthat/_snaps/partydf.md
+++ b/tests/testthat/_snaps/partydf.md
@@ -37,3 +37,27 @@
       6     6
       # ... with 14 more rows
 
+# name must be data frame with same names
+
+    Code
+      party_df(cl, "x")
+    Condition
+      Error in `party_df()`:
+      ! `x` does not exist on all workers
+
+---
+
+    Code
+      party_df(cl, "x")
+    Condition
+      Error in `party_df()`:
+      ! `x` is not a data frame on all workers
+
+---
+
+    Code
+      party_df(cl, "x")
+    Condition
+      Error in `party_df()`:
+      ! `x` does not have the same names on all workers
+

--- a/tests/testthat/test-dplyr-dual.R
+++ b/tests/testthat/test-dplyr-dual.R
@@ -2,7 +2,9 @@ test_that("joining data frame requires explicit copy", {
   pf <- partition(data.frame(x = 1:6), default_cluster())
   df <- data.frame(x = 1:3, y = 3:1)
 
-  expect_error(left_join(pf, df), "same src")
+  expect_snapshot(error = TRUE, {
+    left_join(pf, df)
+  })
   expect_error(left_join(pf, df, copy = TRUE), NA)
 })
 

--- a/tests/testthat/test-partydf.R
+++ b/tests/testthat/test-partydf.R
@@ -17,14 +17,14 @@ test_that("can construct and print partydf", {
 
 test_that("name must be data frame with same names", {
   cl <- default_cluster()
-  expect_error(party_df(cl, "x"), "does not exist")
+  expect_snapshot(error = TRUE, party_df(cl, "x"))
 
   cluster_assign(cl, x = 1)
   on.exit(cluster_rm(cl, "x"))
-  expect_error(party_df(cl, "x"), "not a data frame")
+  expect_snapshot(error = TRUE, party_df(cl, "x"))
 
   cluster_assign_each(cl, x = list(tibble(x = 1), tibble(y = 2)))
-  expect_error(party_df(cl, "x"), "same names")
+  expect_snapshot(error = TRUE, party_df(cl, "x"))
 })
 
 test_that("can automatically delete on gc() + cluster_call()", {


### PR DESCRIPTION
In dplyr 1.1.1, `auto_copy()` now throws a different and much improved error message. multidplyr was expecting the old error message in a test and wasn't using snapshot testing. https://github.com/tidyverse/dplyr/pull/6800

``` r
pf <- partition(data.frame(x = 1:6), default_cluster())
#> Initialising default cluster of size 2
df <- data.frame(x = 1:3, y = 3:1)

# Before
left_join(pf, df)
#> Error in `auto_copy()` at multidplyr/R/dplyr-dual.R:20:2:
#> ! `x` and `y` must share the same src.
#> ℹ set `copy` = TRUE (may be slow).

# After
left_join(pf, df)
#> Error in `auto_copy()` at multidplyr/R/dplyr-dual.R:20:2:
#> ! `x` and `y` must share the same source.
#> ℹ `x` is a <multidplyr_party_df> object.
#> ℹ `y` is a <data.frame> object.
#> ℹ Set `copy = TRUE` if `y` can be copied to the same source as `x` (may be slow).
```